### PR TITLE
Install libmotif-dev for Raspbian

### DIFF
--- a/pkg-rpi/epics
+++ b/pkg-rpi/epics
@@ -14,6 +14,7 @@ libpcre++-dev
 #
 #
 #
+libmotif-dev
 libsnmp-dev
 re2c
 darcs


### PR DESCRIPTION
When compiling medm on Raspbian, libmotif-dev is needed.
Install it (similar to Debian).